### PR TITLE
Fixes: Cannot read property 'severity' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function loopMatch(matcher, input) {
           continue;
         }
 
-        let r = runRegExp(re, line, x);
+        let r = runRegExp(re, line, x, matcher);
 
         // If the regexp didn't match, assume that the loop is over and start again
         if (!r) {


### PR DESCRIPTION
This pull request includes a super tiny fix for "Cannot read property 'severity' of undefined".

It happens when using multiline matching with a default severity.

Initial situation:

```
Test Suites: 1 passed, 1 total
Tests:       14 passed, 14 total
```

After adding the new test for multiline matching with a default severity:

```
  ● loop line matcher with default severity, does match

    TypeError: Cannot read property 'severity' of undefined

      138 |
      139 |   if (!matches.severity) {
    > 140 |     matches.severity = matcher.severity;
          |                                ^
      141 |   }
      142 |
      143 |   return matches;

...

Test Suites: 1 failed, 1 total
Tests:       1 failed, 14 passed, 15 total
```

After fixing `loopMatch` function:

```
Test Suites: 1 passed, 1 total
Tests:       15 passed, 15 total
```

## Note

The changes in `package.json` and `package-lock.json` were made automatically by `npm audit fix` after trying to install the packages:

```
$ npm install
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.11 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.11: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})

added 539 packages from 398 contributors and audited 610 packages in 10.778s

15 packages are looking for funding
  run `npm fund` for details

found 40987 vulnerabilities (38091 low, 83 moderate, 2812 high, 1 critical)
  run `npm audit fix` to fix them, or `npm audit` for details
```
